### PR TITLE
feat(matrix): add custom bridge configuration

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for Matrix.org, includes Synapse, PostgreSQL, and Element.
 
 type: application
 
-version: 2.6.3
+version: 2.6.4
 
 # The version of Synapse
 appVersion: "1.136.0"

--- a/charts/matrix/templates/bridges-configmap.yaml
+++ b/charts/matrix/templates/bridges-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.bridges }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "matrix.fullname" . }}-bridges
+  labels:
+    {{- include "matrix.labels" . | nindent 4 }}
+data:
+{{- range .Values.bridges }}
+  {{ .name }}.yaml: |
+{{ .config | nindent 4 }}
+{{- end }}
+{{- end }}
+

--- a/charts/matrix/templates/configmap.yaml
+++ b/charts/matrix/templates/configmap.yaml
@@ -48,3 +48,9 @@ data:
     report_stats: false
   homeserver.yaml: |
     {{- .Values.homeserverConfig | toYaml | nindent 4 }}
+    {{ if .Values.bridges }}
+    app_service_config_files:
+    {{ range .Values.bridges }}
+      - /etc/synapse/bridges/{{ .name }}.yaml
+    {{ end }}
+    {{ end }}

--- a/charts/matrix/templates/deployment.yaml
+++ b/charts/matrix/templates/deployment.yaml
@@ -126,6 +126,10 @@ spec:
               name: config
             - mountPath: /etc/synapse/secret
               name: secret
+            {{- if .Values.bridges }}
+            - mountPath: /etc/synapse/bridges
+              name: bridges
+            {{- end }}
             {{- if .Values.postgresql.enabled }}
             - mountPath: /etc/synapse/postgresql-password
               name: postgresql-password
@@ -164,6 +168,11 @@ spec:
         - name: secret
           secret:
             secretName: {{ .Values.secret.name | default (include "matrix.fullname" .) | quote }}
+        {{- if .Values.bridges }}
+        - name: bridges
+          configMap:
+            name: {{ include "matrix.fullname" . }}-bridges
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: postgresql-password
           secret:

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -71,6 +71,13 @@ extraConfig: []
 #      name: matrix-rooms
 #      key: rooms
 
+# Custom bridge registrations
+bridges: []
+# - name: googlechat
+#   config: |
+#     id: googlechat
+#     url: http://googlechat-bridge:9000
+
 logConfig:
   version: 1
   disable_existing_loggers: false


### PR DESCRIPTION
## Summary
- allow defining bridges with name and config in values.yaml
- mount bridge registration files via separate ConfigMap
- auto-populate app_service_config_files for custom bridges

## Testing
- `helm lint charts/matrix`
- `helm template test charts/matrix -f /tmp/test-values.yaml | grep -n -A2 "app_service_config_files"`

------
https://chatgpt.com/codex/tasks/task_e_68a2531bf7d88320a30fd686f4c45c6f